### PR TITLE
Simplify the constraint category

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,57 +84,63 @@
 
         haskell = concat.lib.haskellOverlay cabalPackages;
 
-        haskellDependencies = final: prev: hfinal: hprev: (
-          if nixpkgs.lib.versionAtLeast hprev.ghc.version "9.8.0"
-          then let
-            hspecVersion = "2_11_7";
-          in {
-            ## The default versions in Nixpkgs 23.11 don’t support GHC 9.8.
-            doctest = hfinal.doctest_0_22_2;
-            hedgehog = hfinal."hedgehog_1_4";
-            hedgehog-fn = final.haskell.lib.doJailbreak hprev.hedgehog-fn;
-            hspec = hfinal."hspec_${hspecVersion}";
-            hspec-core = hfinal."hspec-core_${hspecVersion}";
-            hspec-discover = hfinal."hspec-discover_${hspecVersion}";
-            hspec-meta = hfinal."hspec-meta_${hspecVersion}";
-            semigroupoids = hfinal.semigroupoids_6_0_0_1;
-            tagged = hfinal.tagged_0_8_8;
-            th-abstraction = hfinal.th-abstraction_0_6_0_0;
-            ## `Control.Monad.Trans.List` is gone with GHC 9.8, but
-            ## `lifted-base` hasn’t updated its tests to avoid it.
-            lifted-base = final.haskell.lib.dontCheck hprev.lifted-base;
-            ## The default versions in Nixpkgs 23.11 don’t support
-            ## th-abstraction 0.6.
-            aeson = final.haskell.lib.doJailbreak hprev.aeson;
-            bifunctors = hfinal.bifunctors_5_6_1;
-            free = hfinal.free_5_2;
+        haskellDependencies = final: prev: hfinal: hprev:
+          {
+            constraints = hfinal.constraints_0_14;
+            constraints-extras =
+              final.haskell.lib.doJailbreak hprev.constraints-extras;
           }
-          ## TODO: The failures that led to this are inconsistent, but
-          ##       persistent.
-          else if nixpkgs.lib.versionAtLeast hprev.ghc.version "9.6.0"
-          then {
-            ormolu = hfinal.ormolu_0_7_2_0;
-            streaming-commons =
-              final.haskell.lib.dontCheck hprev.streaming-commons;
-          }
-          else if nixpkgs.lib.versionAtLeast hprev.ghc.version "8.10.0"
-          then {}
-          else
-            {
-              ## NB: Fails a single test case under GHC 8.8.4.
-              doctest = final.haskell.lib.dontCheck hprev.doctest;
-              ## NB: Tests fail to build under GHC 8.8.4.
-              vector = final.haskell.lib.dontCheck hprev.vector;
+          // (
+            if nixpkgs.lib.versionAtLeast hprev.ghc.version "9.8.0"
+            then let
+              hspecVersion = "2_11_7";
+            in {
+              ## The default versions in Nixpkgs 23.11 don’t support GHC 9.8.
+              doctest = hfinal.doctest_0_22_2;
+              hedgehog = hfinal."hedgehog_1_4";
+              hedgehog-fn = final.haskell.lib.doJailbreak hprev.hedgehog-fn;
+              hspec = hfinal."hspec_${hspecVersion}";
+              hspec-core = hfinal."hspec-core_${hspecVersion}";
+              hspec-discover = hfinal."hspec-discover_${hspecVersion}";
+              hspec-meta = hfinal."hspec-meta_${hspecVersion}";
+              semigroupoids = hfinal.semigroupoids_6_0_0_1;
+              tagged = hfinal.tagged_0_8_8;
+              th-abstraction = hfinal.th-abstraction_0_6_0_0;
+              ## `Control.Monad.Trans.List` is gone with GHC 9.8, but
+              ## `lifted-base` hasn’t updated its tests to avoid it.
+              lifted-base = final.haskell.lib.dontCheck hprev.lifted-base;
+              ## The default versions in Nixpkgs 23.11 don’t support
+              ## th-abstraction 0.6.
+              aeson = final.haskell.lib.doJailbreak hprev.aeson;
+              bifunctors = hfinal.bifunctors_5_6_1;
+              free = hfinal.free_5_2;
             }
-            // (
-              if final.system == "i686-linux"
-              then {
-                ## NB: Fails `prop_double_assoc` under GHC 8.8.4 on i686-linux.
-                QuickCheck = final.haskell.lib.dontCheck hprev.QuickCheck;
+            ## TODO: The failures that led to this are inconsistent, but
+            ##       persistent.
+            else if nixpkgs.lib.versionAtLeast hprev.ghc.version "9.6.0"
+            then {
+              ormolu = hfinal.ormolu_0_7_2_0;
+              streaming-commons =
+                final.haskell.lib.dontCheck hprev.streaming-commons;
+            }
+            else if nixpkgs.lib.versionAtLeast hprev.ghc.version "8.10.0"
+            then {}
+            else
+              {
+                ## NB: Fails a single test case under GHC 8.8.4.
+                doctest = final.haskell.lib.dontCheck hprev.doctest;
+                ## NB: Tests fail to build under GHC 8.8.4.
+                vector = final.haskell.lib.dontCheck hprev.vector;
               }
-              else {}
-            )
-        );
+              // (
+                if final.system == "i686-linux"
+                then {
+                  ## NB: Fails `prop_double_assoc` under GHC 8.8.4 on i686-linux.
+                  QuickCheck = final.haskell.lib.dontCheck hprev.QuickCheck;
+                }
+                else {}
+              )
+          );
       };
 
       homeConfigurations =

--- a/haskerwaul/haskerwaul.cabal
+++ b/haskerwaul/haskerwaul.cabal
@@ -163,8 +163,8 @@ custom-setup
 library
   import: defaults
   build-depends:
-    -- NB: constraints < 0.11 results in extra redundant constraints.
-    constraints ^>= {0.11, 0.13.1, 0.14},
+    -- NB: constraints 0.14 adds an internal hom and a Cartesian product
+    constraints ^>= {0.14},
     containers ^>= {0.6.0},
   hs-source-dirs:
     src

--- a/haskerwaul/src/Haskerwaul/Bifunctor.hs
+++ b/haskerwaul/src/Haskerwaul/Bifunctor.hs
@@ -8,7 +8,7 @@
 module Haskerwaul.Bifunctor where
 
 import qualified Data.Bifunctor as Base
-import Data.Constraint (Class (..), trans, (***), (:-) (..), (:=>) (..), (\\))
+import Data.Constraint (Class (..), Dict (Dict), (***), (:-) (Sub), (:=>) (..), (\\), type (&))
 import Data.Functor.Const (Const (..))
 import Data.Proxy (Proxy (..))
 #if MIN_VERSION_base(4, 17, 0)
@@ -105,8 +105,8 @@ instance
   where
   bimap f g = DT (\(Procompose x y) -> Procompose (runDT f x) (runDT g y))
 
-instance Bifunctor (:-) (:-) (:-) Combine where
-  bimap f g = trans ins (trans (f *** g) cls)
+instance Bifunctor (:-) (:-) (:-) (&) where
+  bimap f g = Sub (Dict \\ f \\ g)
 
 instance
   Bifunctor
@@ -115,7 +115,7 @@ instance
     (NaturalTransformation c (:-))
     CFProd
   where
-  bimap f g = NT (trans (trans ins (runNT f *** runNT g)) cls)
+  bimap f g = NT (ins . (runNT f *** runNT g) . cls)
 
 instance Bifunctor c1 c2 (->) (BConst a) where
   bimap _ _ (BConst a) = BConst a

--- a/haskerwaul/src/Haskerwaul/Category/Closed.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Closed.hs
@@ -12,7 +12,7 @@ module Haskerwaul.Category.Closed
   )
 where
 
-import Data.Constraint ((:-), (:=>))
+import Data.Constraint ((:-), type (|-))
 import Data.Kind (Type)
 #if MIN_VERSION_base(4, 17, 0)
 import Data.Type.Equality (type (~))
@@ -26,15 +26,20 @@ import Haskerwaul.Monad
 import Haskerwaul.Object
 import Haskerwaul.Transformation.Natural
 
--- | [nLab](https://ncatlab.org/nlab/show/closed+category)
+-- |
+--
+-- = references
+--
+-- - [nLab](https://ncatlab.org/nlab/show/closed+category)
 --
 --  __TODO__: This should have a
---           @`Haskerwaul.Bifunctor.Bifunctor` (`Opposite` c) c c (`InternalHom` c)@
---            constraint, but it's been troublesome making an instance for
---            `(:=>)`, so we skip the constraint here and add it on the
---            instances that make use of it.
+--            @`Haskerwaul.Bifunctor.Bifunctor` (`Opposite` c) c c (`InternalHom` c)@
+--            constraint, but it's been troublesome making an instance for `|-`,
+--            so we skip the constraint here and add it on the instances that
+--            make use of it.
 class (Category c, TOb (Ob c) (InternalHom c)) => ClosedCategory (c :: ok -> ok -> Type) where
   -- |
+  --
   -- = references
   --
   -- - [nLab](https://ncatlab.org/nlab/show/internal+hom)
@@ -63,10 +68,10 @@ instance
 #endif
 
 instance ClosedCategory (:-) where
-  type InternalHom (:-) = (:=>)
+  type InternalHom (:-) = (|-)
 
 instance ClosedCategory (NaturalTransformation c (:-)) where
-  type InternalHom (NaturalTransformation c (:-)) = ConstraintTransformation (:-)
+  type InternalHom (NaturalTransformation c (:-)) = ConstraintTransformation
 
 instance
   (ClosedCategory c, TOb (Ob c) (Opposite (InternalHom c))) =>

--- a/haskerwaul/src/Haskerwaul/Category/Monoidal.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Monoidal.hs
@@ -14,7 +14,7 @@ module Haskerwaul.Category.Monoidal
 where
 
 import qualified Control.Category as Base
-import Data.Constraint (cls, ins, refl, top, trans, weaken1, weaken2, (&&&), (:-))
+import Data.Constraint (Dict (Dict), (:-) (Sub), type (&))
 import Data.Either (Either (..))
 import qualified Data.Either as Base
 import Data.Functor.Const (Const (..))
@@ -97,16 +97,10 @@ instance (MonoidalCategory c t) => MonoidalCategory (Isomorphism c) t where
   leftIdentity = Iso leftIdentity (reverse leftIdentity)
   rightIdentity = Iso rightIdentity (reverse rightIdentity)
 
-instance MonoidalCategory (:-) Combine where
-  leftIdentity = Iso (trans weaken2 cls) (trans ins (top &&& refl))
-  rightIdentity = Iso (trans weaken1 cls) (trans ins (refl &&& top))
+instance MonoidalCategory (:-) (&) where
+  leftIdentity = Iso (Sub Dict) (Sub Dict)
+  rightIdentity = Iso (Sub Dict) (Sub Dict)
 
 instance MonoidalCategory (NaturalTransformation c (:-)) CFProd where
-  leftIdentity =
-    Iso
-      (NT (trans weaken2 cls))
-      (NT (trans ins (trans ins top &&& refl)))
-  rightIdentity =
-    Iso
-      (NT (trans weaken1 cls))
-      (NT (trans ins (refl &&& trans ins top)))
+  leftIdentity = Iso (NT (Sub Dict)) (NT (Sub Dict))
+  rightIdentity = Iso (NT (Sub Dict)) (NT (Sub Dict))

--- a/haskerwaul/src/Haskerwaul/Category/Monoidal/Balanced.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Monoidal/Balanced.hs
@@ -15,7 +15,7 @@ module Haskerwaul.Category.Monoidal.Balanced
   )
 where
 
-import Data.Constraint ((:-))
+import Data.Constraint ((:-), type (&))
 import Data.Either (Either (..))
 import Data.Proxy (Proxy (..))
 #if MIN_VERSION_base(4, 17, 0)
@@ -54,7 +54,7 @@ instance
   where
   balance Proxy = NT (balance (Proxy :: Proxy dt))
 
-instance BalancedMonoidalCategory (:-) Combine where
+instance BalancedMonoidalCategory (:-) (&) where
   balance Proxy = id
 
 instance BalancedMonoidalCategory (NaturalTransformation c (:-)) CFProd where

--- a/haskerwaul/src/Haskerwaul/Category/Monoidal/Braided.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Monoidal/Braided.hs
@@ -12,7 +12,7 @@ module Haskerwaul.Category.Monoidal.Braided
   )
 where
 
-import Data.Constraint (Dict (..), (:-) (..))
+import Data.Constraint (Dict (..), (:-) (..), type (&))
 import Data.Either (Either (..))
 import qualified Data.Tuple as Base
 #if MIN_VERSION_base(4, 17, 0)
@@ -56,7 +56,7 @@ instance
       (NT (FTensor . to braid . lowerFTensor))
       (NT (FTensor . from braid . lowerFTensor))
 
-instance BraidedMonoidalCategory (:-) Combine where
+instance BraidedMonoidalCategory (:-) (&) where
   braid = Iso (Sub Dict) (Sub Dict)
 
 instance BraidedMonoidalCategory (NaturalTransformation c (:-)) CFProd where

--- a/haskerwaul/src/Haskerwaul/Category/Monoidal/Cartesian.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Monoidal/Cartesian.hs
@@ -13,14 +13,7 @@ module Haskerwaul.Category.Monoidal.Cartesian
   )
 where
 
-import Data.Constraint
-  ( Dict (..),
-    cls,
-    trans,
-    weaken1,
-    weaken2,
-    (:-) (..),
-  )
+import Data.Constraint (Dict (Dict), (:-) (Sub), type (&))
 import Data.Kind (Type)
 import qualified Data.Tuple as Base
 #if MIN_VERSION_base(4, 17, 0)
@@ -91,15 +84,15 @@ instance CartesianMonoidalCategory (NaturalTransformation c (->)) where
   diagonal = NT (FTensor . diagonal)
 
 instance CartesianMonoidalCategory (:-) where
-  type Prod (:-) = Combine
-  exl = trans weaken1 cls
-  exr = trans weaken2 cls
+  type Prod (:-) = (&)
+  exl = Sub Dict
+  exr = Sub Dict
   diagonal = Sub Dict
 
 instance CartesianMonoidalCategory (NaturalTransformation c (:-)) where
   type Prod (NaturalTransformation c (:-)) = CFProd
-  exl = NT (trans weaken1 cls)
-  exr = NT (trans weaken2 cls)
+  exl = NT (Sub Dict)
+  exr = NT (Sub Dict)
   diagonal = NT (Sub Dict)
 
 instance

--- a/haskerwaul/src/Haskerwaul/Category/Monoidal/Symmetric.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Monoidal/Symmetric.hs
@@ -12,7 +12,7 @@ module Haskerwaul.Category.Monoidal.Symmetric
   )
 where
 
-import Data.Constraint ((:-))
+import Data.Constraint ((:-), type (&))
 import Data.Either (Either (..))
 #if MIN_VERSION_base(4, 17, 0)
 import Data.Type.Equality (type (~))
@@ -53,7 +53,7 @@ instance
   (d ~ (->), dt ~ (,), SymmetricMonoidalCategory d dt) =>
   SymmetricMonoidalCategory (NaturalTransformation c d) (FTensor dt)
 
-instance SymmetricMonoidalCategory (:-) Combine
+instance SymmetricMonoidalCategory (:-) (&)
 
 instance SymmetricMonoidalCategory (NaturalTransformation c (:-)) CFProd
 

--- a/haskerwaul/src/Haskerwaul/Category/MonoidalUnit.hs
+++ b/haskerwaul/src/Haskerwaul/Category/MonoidalUnit.hs
@@ -6,11 +6,10 @@
 -- | This module exists to break the cycle with "Haskerwaul.Magma.Unital".
 module Haskerwaul.Category.MonoidalUnit where
 
-import Data.Constraint ((:-))
+import Data.Constraint ((:-), type (&))
 import Data.Either (Either (..))
 import Data.Kind (Constraint, Type)
 import Data.Void (Void)
-import Haskerwaul.Constraint
 import Haskerwaul.Object
 
 -- |
@@ -35,5 +34,5 @@ instance MonoidalCategory' (->) (,) where
 instance MonoidalCategory' (->) Either where
   type Unit (->) Either = Void
 
-instance MonoidalCategory' (:-) Combine where
-  type Unit (:-) Combine = (() :: Constraint)
+instance MonoidalCategory' (:-) (&) where
+  type Unit (:-) (&) = (() :: Constraint)

--- a/haskerwaul/src/Haskerwaul/Category/Opposite.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Opposite.hs
@@ -15,7 +15,7 @@
 module Haskerwaul.Category.Opposite where
 
 import Control.Arrow ((&&&))
-import Data.Constraint (Bottom (..), bottom, (:-) (..))
+import Data.Constraint (Bottom, bottom, (:-))
 import Data.Either (Either (..))
 import Data.Function (const)
 import Data.Functor.Compose (Compose (..))
@@ -39,7 +39,12 @@ import Haskerwaul.Object
 import Haskerwaul.Transformation.Dinatural
 import Haskerwaul.Transformation.Natural
 
--- | [nLab](https://ncatlab.org/nlab/show/opposite+category)
+-- |
+--
+-- = references
+--
+-- - [nLab](https://ncatlab.org/nlab/show/opposite+category)
+-- - [Wikipedia](https://en.wikipedia.org/wiki/Opposite_category)
 newtype Opposite c a b = Opposite {opposite :: b `c` a}
 
 type instance Ob (Opposite c) = Ob c
@@ -175,9 +180,8 @@ instance
 instance (Semicategory c) => Bifunctor (Opposite c) c (->) c where
   bimap f g fn = g . fn . opposite f
 
--- instance Bifunctor (Opposite (:-)) (:-) (:-) (:=>) where
---   -- bimap :: b :- a -> c :- d -> (a :=> c) :- (b :=> d)
---   bimap f g = trans g (trans ins (opposite f))
+-- instance Bifunctor (Opposite (:-)) (:-) (:-) (|-) where
+--   bimap f g = Sub (Dict \\ opposite f \\ g)
 
 -- __NB__: The equivalent context @(Monad' (->) m)@ leads to a deduction failure.
 instance

--- a/haskerwaul/src/Haskerwaul/Category/Semigroupal.hs
+++ b/haskerwaul/src/Haskerwaul/Category/Semigroupal.hs
@@ -12,7 +12,7 @@ module Haskerwaul.Category.Semigroupal
   )
 where
 
-import Data.Constraint (Class (..), Dict (..), refl, trans, (***), (:-) (..), (:=>) (..))
+import Data.Constraint (Dict (Dict), (:-) (Sub), type (&))
 import Data.Either (Either (..))
 import Data.Proxy (Proxy (..))
 #if MIN_VERSION_base(4, 17, 0)
@@ -75,11 +75,8 @@ instance
 instance (SemigroupalCategory c t) => SemigroupalCategory (Isomorphism c) t where
   assoc = Iso assoc (reverse assoc)
 
-instance SemigroupalCategory (:-) Combine where
-  assoc =
-    Iso
-      (trans ins (trans (ins *** refl) (trans (Sub Dict) (trans (refl *** cls) cls))))
-      (trans ins (trans (refl *** ins) (trans (Sub Dict) (trans (cls *** refl) cls))))
+instance SemigroupalCategory (:-) (&) where
+  assoc = Iso (Sub Dict) (Sub Dict)
 
 instance SemigroupalCategory (NaturalTransformation c (:-)) CFProd where
   assoc = Iso (NT (Sub Dict)) (NT (Sub Dict))

--- a/haskerwaul/src/Haskerwaul/Constraint.hs
+++ b/haskerwaul/src/Haskerwaul/Constraint.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE Safe #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -11,26 +12,13 @@
 --   classes.
 module Haskerwaul.Constraint where
 
-import Data.Constraint (Class (..), Dict (..), (:-) (..), (:=>) (..))
-import Data.Functor.Compose (Compose (..))
-import Data.Kind (Constraint)
+import Data.Constraint (Class (cls), Dict (Dict), (:-) (Sub), (:=>) (ins))
+import Data.Functor.Compose (Compose (getCompose))
 
 -- | A natural transformation in the category of constraints.
-class
-  (f a :=> g a) =>
-  ConstraintTransformation
-    c
-    (f :: ok -> Constraint)
-    (g :: ok -> Constraint)
-    a
-  where
-  constrainNT :: f a `c` g a
+class ((f a) => g a) => ConstraintTransformation f g a
 
-instance (f a :=> g a) => ConstraintTransformation (:-) f g a where
-  constrainNT = ins
-
-instance (f a :=> g a) :=> ConstraintTransformation (:-) f g a where
-  ins = Sub Dict
+instance ((f a) => g a) => ConstraintTransformation f g a
 
 -- | The `Haskerwaul.Category.Monoidal.Cartesian.Prod` for that category. The
 --   name is for /C/onstraint-valued /F/unctor /Prod/uct.
@@ -49,9 +37,6 @@ class All a
 
 instance All a
 
-instance () :=> All a where
-  ins = Sub Dict
-
 -- | Like `Data.Constraint.Bottom, but for @k -> `Data.Kind.Constraint`@. It
 --   should be impossible to create an instance for this.
 class None a where
@@ -59,16 +44,3 @@ class None a where
 
 none :: None a :- f a
 none = Sub (getCompose nope)
-
--- | Because @,@ is handled oddly, we can't use it in
---  @`Haskerwaul.Category.Semigroupal.SemigroupalCategory` (`:-`) (,)@. This
---   is our workaround.
-class (a, b) => Combine a b
-
-instance (a, b) => Combine a b
-
-instance Class (a, b) (Combine a b) where
-  cls = Sub Dict
-
-instance (a, b) :=> Combine a b where
-  ins = Sub Dict

--- a/haskerwaul/src/Haskerwaul/Magma.hs
+++ b/haskerwaul/src/Haskerwaul/Magma.hs
@@ -8,7 +8,7 @@ module Haskerwaul.Magma where
 import qualified Control.Category as Base
 import qualified Data.Bifunctor as Base
 import Data.Bool (Bool)
-import Data.Constraint (Dict (..), top, (:-) (..))
+import Data.Constraint (Dict (..), top, (:-) (..), type (&))
 import Data.Either (Either (..))
 import Data.Int (Int, Int16, Int32, Int64, Int8)
 import Data.Kind (Constraint)
@@ -19,7 +19,6 @@ import qualified Data.Tuple as Base
 import Data.Type.Equality ((:~:) (Refl))
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import Haskerwaul.Categorification.Horizontal
-import Haskerwaul.Constraint
 import Haskerwaul.Lattice.Components
 import Haskerwaul.Object
 import Haskerwaul.Transformation.Dinatural
@@ -137,7 +136,7 @@ instance Magma (->) (,) (Join Word64) where
 instance Magma (->) (,) (Meet Word64) where
   op = Meet Base.. Base.uncurry Base.min Base.. Base.bimap getMeet getMeet
 
-instance Magma (:-) Combine (() :: Constraint) where
+instance Magma (:-) (&) (() :: Constraint) where
   op = top
 
 -- __NB__: These definitions belong in "Haskerwaul.Magmoid", but they’d be

--- a/haskerwaul/src/Haskerwaul/Magma/Flexible.hs
+++ b/haskerwaul/src/Haskerwaul/Magma/Flexible.hs
@@ -12,7 +12,7 @@ where
 
 import qualified Control.Category as Base
 import Data.Bool (Bool)
-import Data.Constraint ((:-) (..))
+import Data.Constraint ((:-) (..), type (&))
 import Data.Either (Either)
 import Data.Int (Int, Int16, Int32, Int64, Int8)
 import Data.Kind (Constraint)
@@ -20,7 +20,6 @@ import qualified Data.Semigroup as Base
 import Data.Type.Equality ((:~:))
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import Haskerwaul.Categorification.Horizontal
-import Haskerwaul.Constraint
 import Haskerwaul.Lattice.Components
 import Haskerwaul.Magma
 import Haskerwaul.Semiring.Components
@@ -45,7 +44,7 @@ instance
   (FlexibleMagma (->) (,) a, FlexibleMagma (->) (,) b) =>
   FlexibleMagma (->) (,) (a, b)
 
-instance FlexibleMagma (:-) Combine (() :: Constraint)
+instance FlexibleMagma (:-) (&) (() :: Constraint)
 
 instance FlexibleMagma (->) Either a
 

--- a/haskerwaul/src/Haskerwaul/Magma/Unital.hs
+++ b/haskerwaul/src/Haskerwaul/Magma/Unital.hs
@@ -14,7 +14,7 @@ where
 
 import qualified Control.Category as Base
 import Data.Bool (Bool (..))
-import Data.Constraint (Dict (..), refl, (:-) (..))
+import Data.Constraint (Dict (..), refl, (:-) (..), type (&))
 import Data.Either (Either)
 import Data.Int (Int, Int16, Int32, Int64, Int8)
 import Data.Kind (Constraint)
@@ -25,7 +25,6 @@ import qualified Data.Void as Base
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import Haskerwaul.Categorification.Horizontal
 import Haskerwaul.Category.MonoidalUnit
-import Haskerwaul.Constraint
 import Haskerwaul.Lattice.Components
 import Haskerwaul.Magma
 import Haskerwaul.Object
@@ -219,7 +218,7 @@ instance UnitalMagma (->) (,) (Meet Word64) where
 instance UnitalMagma (->) (,) (Multiplicative Word64) where
   unit Proxy () = Multiply 1
 
-instance UnitalMagma (:-) Combine (() :: Constraint) where
+instance UnitalMagma (:-) (&) (() :: Constraint) where
   unit Proxy = refl
 
 -- __NB__: These definitions belong in "Haskerwaul.Magma.Unital", but they’d be

--- a/haskerwaul/src/Haskerwaul/Object/Terminal.hs
+++ b/haskerwaul/src/Haskerwaul/Object/Terminal.hs
@@ -6,7 +6,7 @@
 
 module Haskerwaul.Object.Terminal where
 
-import Data.Constraint (Dict (..), (:-) (..))
+import Data.Constraint (Dict (Dict), top, (:-) (Sub))
 import Data.Functor.Const (Const (..))
 import Data.Kind (Constraint, Type)
 #if MIN_VERSION_base(4, 17, 0)
@@ -34,7 +34,7 @@ instance HasTerminalObject (->) where
 
 instance HasTerminalObject (:-) where
   type TerminalObject (:-) = (() :: Constraint)
-  (!) = Sub Dict
+  (!) = top
 
 instance HasTerminalObject (NaturalTransformation c (:-)) where
   type TerminalObject (NaturalTransformation c (:-)) = All

--- a/haskerwaul/src/Haskerwaul/Semigroup.hs
+++ b/haskerwaul/src/Haskerwaul/Semigroup.hs
@@ -12,7 +12,7 @@ where
 
 import qualified Control.Category as Base
 import Data.Bool (Bool)
-import Data.Constraint (Dict (..), (:-) (..))
+import Data.Constraint (Dict (..), (:-) (..), type (&))
 import Data.Either (Either)
 import Data.Int (Int, Int16, Int32, Int64, Int8)
 import Data.Kind (Constraint)
@@ -20,7 +20,6 @@ import qualified Data.Semigroup as Base
 import Data.Type.Equality ((:~:))
 import Data.Word (Word, Word16, Word32, Word64, Word8)
 import Haskerwaul.Categorification.Horizontal
-import Haskerwaul.Constraint
 import Haskerwaul.Lattice.Components
 import Haskerwaul.Magma.Flexible
 import Haskerwaul.Object
@@ -103,7 +102,7 @@ instance Semigroup (->) (,) (Join Word64)
 
 instance Semigroup (->) (,) (Meet Word64)
 
-instance Semigroup (:-) Combine (() :: Constraint)
+instance Semigroup (:-) (&) (() :: Constraint)
 
 -- __NB__: These definitions belong in "Haskerwaul.Semicategory", but they’d be
 --         orphans there.

--- a/hedgehog/haskerwaul-hedgehog.cabal
+++ b/hedgehog/haskerwaul-hedgehog.cabal
@@ -162,7 +162,7 @@ custom-setup
 library
   import: defaults
   build-depends:
-    constraints ^>= {0.11, 0.13.1, 0.14},
+    constraints ^>= {0.14},
     haskerwaul ^>= {0.1.0},
     -- NB: hedgehog < 1.0 doesn’t export `label`, which we need for building up
     --     complex test cases.


### PR DESCRIPTION
Mostly this replaces `:=>` and `Combine` with `|-` and `&`, which were introduced in constraints-0.14.